### PR TITLE
Refactor entry point discovery code. Remove format_exc_info.

### DIFF
--- a/servicelayer/extensions.py
+++ b/servicelayer/extensions.py
@@ -1,6 +1,6 @@
 import logging
 from threading import RLock
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 
 log = logging.getLogger(__name__)
 lock = RLock()
@@ -12,7 +12,7 @@ def get_entry_points(section):
     with lock:
         if section not in EXTENSIONS:
             EXTENSIONS[section] = {}
-            for ep in iter_entry_points(section):
+            for ep in entry_points(group=section):
                 EXTENSIONS[section][ep.name] = ep.load()
         return EXTENSIONS[section]
 

--- a/servicelayer/logs.py
+++ b/servicelayer/logs.py
@@ -21,7 +21,6 @@ def configure_logging(level=logging.INFO):
         structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f"),
         structlog.processors.StackInfoRenderer(),
         structlog.dev.set_exc_info,
-        structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
     ]
     if settings.LOG_FORMAT == LOG_FORMAT_TEXT:


### PR DESCRIPTION
[pkg_resources is deprecated and removed in Python 3.12](https://github.com/mu-editor/mu/issues/2485). This PR replaces the code that `get_entry_points` uses to discover all Python classes registered at a given entry point with code that uses the `entry_points` method from `importlib.metadata`.

This PR also removes `format_exc_info` in order to [implement pretty exceptions](https://www.structlog.org/en/21.3.0/changelog.html).